### PR TITLE
Fix schedule ending at midnight and wrong rain status if plugin started when wet

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Standby, Mowing, Going home, Charging, Border, Error
 **Zone 4** - percentage of the start of zone 4
 
 ## Text
-*Format of the text fields: Start and end time format HH:MM. Add Trim to mowe the border. ex. "06:15 - 17:00 Trim" or "06:15 - 17:00"*
+*Format of the text fields: Start and end time format HH:MM. Add Trim to mowe the border. ex. "06:15 - 17:00 Trim", "06:15 - 17:00", "08:00 - 24:00" or whole day "00:00 - 24:00"*
 
 **Schedule Monday** - Text field to update the moday schedule. 
 

--- a/custom_components/sunseeker/sunseeker.py
+++ b/custom_components/sunseeker/sunseeker.py
@@ -72,6 +72,7 @@ class SunseekerDevice:
         self.rain_en = self.devicedata["data"].get("rainFlag")
         self.rain_delay_set = int(self.devicedata["data"].get("rainDelayDuration"))
         self.rain_delay_left = self.devicedata["data"].get("rainDelayLeft")
+        self.rain_status = int(self.devicedata["data"].get("rainStatusCode"))
         if self.devicedata["data"].get("onlineFlag"):
             self.deviceOnlineFlag = '{"online":"1"}'
         self.zoneOpenFlag = self.settings["data"].get("zoneOpenFlag")
@@ -160,7 +161,10 @@ class SunseekerSchedule:
             if Start is not None:
                 asc.start = time.strftime("%H:%M", time.gmtime(int(Start) * 60))[0:5]
             if End is not None:
-                asc.end = time.strftime("%H:%M", time.gmtime(int(End) * 60))[0:5]
+                if int(End) == 1440:
+                    asc.end = "24:00"
+                else:
+                    asc.end = time.strftime("%H:%M", time.gmtime(int(End) * 60))[0:5]
             if Trimming is not None:
                 asc.trim = Trimming
 


### PR DESCRIPTION
Fixes:
- When the schedule ended at midnight ("endAt": "24:00:00") UpdateFromMqtt changed 24:00 to 00:00 meaning that the date's schedule was removed in the next set_schedule call.
- rainStatusCode will be read in InitValues. If the plugin was initialized when it is wet it was showing default status value "Dry" until the rain status was updated from mqtt. It seems like Mqtt will update the rain status only when it is changed, so it might take hours (or days?) to get the correct status when it's raining for a long time.
- Modified documentation with examples of schedule ending at midnight.